### PR TITLE
Create cfignore file that ignores node_modules

### DIFF
--- a/app/templates/.cfignore
+++ b/app/templates/.cfignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Bluemix will run npm install to build dependencies for the app when
deployed. So, no need to push node_modules to Bluemix.
